### PR TITLE
Add `zsh-manydots-magic.plugin.zsh`.

### DIFF
--- a/zsh-manydots-magic.plugin.zsh
+++ b/zsh-manydots-magic.plugin.zsh
@@ -1,0 +1,4 @@
+fpath+="`dirname $0`"
+
+autoload -Uz manydots-magic
+manydots-magic


### PR DESCRIPTION
This allows the repo to be used as a plugin for supporting zsh plugin
managers (such as [antibody](https://getantibody.github.io/)).